### PR TITLE
Added a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+#Default CXX is g++
+CXXFLAGS+=-Wall -std=c++11
+
+PROGRAMS=fasplitter svmu scriptmaker checkCNV
+
+.PHONY: all
+all: $(PROGRAMS)
+
+fasplitter: fasplitter.cpp
+        $(CXX) $(CXXFLAGS) $^ -o $@
+
+svmu: mlib.cpp svmu.cpp
+        $(CXX) $(CXXFLAGS) $^ -o $@
+
+scriptmaker: script_maker.cpp
+        $(CXX) $(CXXFLAGS) $^ -o $@
+
+checkCNV: cnvlib.cpp ccnv.cpp
+        $(CXX) $(CXXFLAGS) $^ -o $@
+
+.PHONY: clean
+clean:
+        rm -f $(PROGRAMS)


### PR DESCRIPTION
Hey Mahul,
Just thought a makefile might simplify installation.

Added a makefile to facilitate compilation, and required C++11 due to usage of "nullptr" in svmu.cpp.  The nullptr keyword was only introduced in C++09, but not incorporated into C++0x, unfortunately: http://stackoverflow.com/questions/1282295/what-exactly-is-nullptr
Tested out on our cluster (had to use G++ > 4.4.7 to compile with --std=c++11), and it compiles fine.

Best regards,
Patrick Reilly
